### PR TITLE
fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: ruby
 rvm:
   - 2.1.2
+before_script:
+  - psql -c 'create database eggcount_test;' -U postgres
+env:
+  - SECRET_TOKEN=$(bundle exec rake secret)
 bundler_args: --without production

--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,7 @@ gem 'rails_12factor', group: :production
 gem 'sass-rails', '~> 4.0.2'
 gem 'turbolinks'
 gem 'uglifier', '>= 1.3.0'
+
+group :development, :test do
+  gem 'rake'
+end

--- a/config/database.yml
+++ b/config/database.yml
@@ -8,7 +8,7 @@ development:
 
 test:
   adapter: postgresql
-  database: travis_ci_test
+  database: eggcount_test
   username: postgres
 
 production:


### PR DESCRIPTION
didn't expect to need the explicit `before_script`...

also travis died when I took out the `rvm` version even though the docs say it should look at the `.ruby-version` file.

[fixes #3]
